### PR TITLE
Add a small section on InnerSource to the first chapter of the FOSS terms guide

### DIFF
--- a/guides/FOSS-terms-guide/02-FOSS-Terms-Intro-Common-Terms.md
+++ b/guides/FOSS-terms-guide/02-FOSS-Terms-Intro-Common-Terms.md
@@ -65,7 +65,7 @@ What is common to be shared?
  - As it turned out: This is actually not very likely.
  - Since you would have to do the work yourself anyway (if its fixing a bug at your side instead, or building a work around, or escalating to another team, etc.). So you would plan the work anyway. 
  - What you do now, is that you include the work of contributing elsewhere and doing work that benefits you, however "lives" in another product/team just like you would plan work that you're doing in your product/team.
- - To handle incoming requests (after all, other people fixing your bugs still benefits you - the same goes with features being added for you) you just plan them the same way. Also, it has turned out to often be beneficial to leave a certain amount of slack in the planning to enable developers to handle open unplannable work.
+ - To handle incoming requests (after all, other people fixing your bugs still benefits you - the same goes with features being added for you) you just plan them the same way. Also, it has turned out to often be beneficial to leave a certain amount of slack in the planning to enable developers to handle open unplannable work (known unknowns).
 
 In InnerSource the entire time, no code leaves the corporate boundaries. Nothing is published to the outside world. 
 You can, of course, decide that you want to turn something that lived as a dedicated InnerSource product/library so far as Open Source. That is a different effort and change of modalities though.


### PR DESCRIPTION
This adds a small section in InnerSource to distinguish it from Open Source and highlight the consequences of that difference.
I thought about putting it into the FOSS terms chapter, but those looked already very FOSS specific. So I added it to the SWE terms. Not really sure about that decision.
Would be happy about a review of content and placement decision from @lauranolling and @wisbech.


