### PR TITLE
Add Open Source vs. Agile segment from pre-read, see #103

### DIFF
--- a/guides/integrating-oss-and-agile.md
+++ b/guides/integrating-oss-and-agile.md
@@ -22,21 +22,39 @@ Here are a few practical suggestions, not necessarily complete but a good starte
 
 ### Handling interrupts / the event driven nature of Open Source
 
-- Prepare yourself to be able to handle interrupts. One good approach here is to leave unplanned room to handle interactions. You could allocate 10-20% of the peoples time to interruptions.
-  - Make sure that you react to events from the Open Source domain timely, usually 2, max. 3 days max are good. Acknowledge their request in a meaningful way, handle it out of the interruption budget if it can be done fast. If not let them know and keep transparent communication in the Open Source project. You can then plan it into your sprints or other agile structures, as you would plan any other task.
-    - Nota bene: Your internal work structures and cadences are usually often not visible to outsiders. Thus, to them it might look like postponed to eternity. If you run an open source project any way, consider handling the work structures openly too. 
-  - Work for InnerSource efforts and Open Source events can be planned and tackled like any other task. It's work that needs to be done, and can be assigned a value contribution and a priority. 
-    - Example: If the task in the end is not „we code 500 lines of code and discuss the domain specifics with business and domain experts for feature X “ but „we mentor and assist person Y with getting a solution that well help them and us to achieve feature X“ it is just as good in the result.
-  - Caveat: Open Source events are external dependencies.  	
-    - The person working with you there is not bound to your schedule or sprints. They might have their own, be a hobbyist, etc. Do not expect your usual cadences and turnaround times.
-    - If a person becomes a repeated contributor, likely some trust will build up. You may even learn where they work or if they're a hobbyist and maybe even some rapport will build up that may allow some aspects of planability across organizations.  		
-      - If you achieve this: Celebrate each other and value that cooperation.  			
+Open Source is event driven, or looks like it is. After all you can not predict what people outside of your scope of influence do, but nevertheless rely on them.
+Hence, it is best to prepare yourself to be able to handle these interrupts/events. 
+One good approach here is to leave unplanned room to handle interactions. You could _allocate 10-20% of the peoples' time to interruptions_.
+There are quite a few more unknown sources of interruptions, even without counting in Open Source or InnerSource participation, anyway. Glancing at the reality of average agile they're just as common there as much as agile might create the illusion of a "plan" or "control".
+
+Nobody likes to wait. Especially if they want to give you a gift, i.e. a contribution.
+Make sure that you react to events from the Open Source (and InnerSource) domain timely, usually 2, max. 3 days max are good.
+Acknowledge their request in a meaningful way, handle it out of the interruption budget if it can be done fast. If not let them know and keep transparent communication in the Open Source project. You can then plan it into your sprints or other agile structures, as you would plan any other task.
+  - Nota bene: Your internal work structures and cadences are usually often not visible to outsiders. Thus, to them it might look like their request is postponed to eternity. If you run an open source project anyway, consider handling the work structures openly too. 
+
+Work for InnerSource efforts and Open Source events can be planned and tackled like any other task. It's work that needs to be done, and can be assigned a value contribution and a priority. 
+  - Example: You need to work around a change in some dependency. Or want a new feature that could live either in your scope or someone else's scope. 
+    - The way of executing this could be "we code 500 lines of code and discuss the domain specifics with business and domain experts for feature X" or "we mentor and assist person Y from another scope with building a solution in our scope that will help them and us to achieve feature X" (assuming the feature is useful for others beyond yourself too)  or "a solution for this will be beneficial for everyone if we build it in another scope. thus we ask a person Y from the other scope if they agree, what variations to feature X they'd like to see to accept it in their scope and then start building it there while being mentored by person Y such that the result is acceptable to them".
+    - All variations result in the same value of feature X. Just that there is less waste, potential for value leverage and creation of ultra-valuable domain level connections to likely strenghten resilience and problem solving skills across the entire company. (And: They exist in most companies anyway, but their existence is often denied turning them into an unknown or risk in the worst case. Thus: Accept them and reap the value they contain.)  
+
+Caveat: Open Source events are external dependencies.
+The person working with you there is not bound to your schedule or sprints. They might have their own, be a hobbyist, etc. Do not expect your usual cadences and turnaround times.
+If a person becomes a repeated contributor, likely some trust will build up. You may even learn where they work or if they're a hobbyist and maybe even some rapport will build up that may allow some aspects of planability across organizations.
+If you achieve this: Celebrate each other and value that cooperation.  		
 
 ### Common expectations of the environment
 
-- Don't feel entitled to contributions or planability even if there have been repeated contributions from the same person. All contributions are gifts. Some gifts just keep on giving.
-- As an agile product manager, you likely cannot keep track of what happens in Open Source projects you use or contribute to. Maybe even tracking all the activity in your own one might become difficult – although, if it's your own Open Source project, you should know what happens, even on the Open Source front. What can you do nevertheless?
-  - Encourage your developers to foster relations with the Open Source projects you depend on so they have a chance to know what's happening there and maybe advocate for some of your needs or see opportunities to contribute or shape things where it might be beneficial for you. They will need time for it; provide that time. It usually has a good ROI on short and longer term.
-  - For your own Open Source projects: You will have trusted committers, which are likely lead developers or people that might one day evolve into an engineering manager. It is the trusted committers job to mentor their community members, advocate for the communities needs, and evolve the product and its roadmap too.
-    - Remember: An Open Source project always needs to be useful to others too – if it only has value for you, nobody else but you will have a reason to care about it. Listen to them and see them as your equal.  		
+Open Source, and by lineage InnerSource too, environments have certain inbuilt expectations of people. If you know and respect them your likelyhood of success is higher. 
+Or as they say: When in Rome, do as the Romans do. 
 
+Don't feel entitled to contributions or planability even if there have been repeated contributions from the same person. All contributions are gifts. Some gifts just keep on giving.
+
+As an agile product manager, you likely cannot keep track of what happens in Open Source projects you use or contribute to. Maybe even tracking all the activity in your own one might become difficult.
+If it's your own Open Source project, you should know what happens, even on the Open Source front. What can you do nevertheless?
+ - Encourage your developers to foster relations with the Open Source projects you depend on so they, and thus by proxy: you,  have a chance to know what's happening in them. This way they may be able advocate for some of your needs and see opportunities to contribute or shape things where it might be beneficial for you. 
+   - They will need time for it; provide that time. It usually has a good ROI on short and longer term.
+ - For your own Open Source projects: You will have trusted committers, which are likely lead developers or people that might one day evolve into an engineering manager. 
+   - It is the trusted committers job to mentor their community members, advocate for the communities needs, and evolve the product and its roadmap too. Listen to them and see them as your equal.
+   - Again: This will cost a relevant amount of time. Provide them with that. It is crucial for success and ROI of your Open Source project.
+
+Remember: An Open Source project always needs to be useful to others too – if it only has value for you, nobody else but you will have a reason to care about it.


### PR DESCRIPTION
This adds the segment on integrating Open Source ways-of-working and Agile as present in the pre-read material.

There are some small changes. We have had some of the "make time and space for the unknowns" discussions at another place, this segment also comes back to this.
A good bit of the material also was part of the discussions with @naltoc on the first workshop.

It's also placed in the guides section. 

Happy about any reviews or ideas around this if you have any @lauranolling.
