### PR TITLE
InnerSource role description from pre-read, see #103

### DIFF
--- a/guides/innersource-short-role-descriptions.md
+++ b/guides/innersource-short-role-descriptions.md
@@ -13,7 +13,7 @@ A short notice on terms:
 
 - *InnerSource* refers to the use of proven Open Source ways of working on closed, corporate IP behind a corporate boundary (internally). 
 
-- *Open Source* refers to the use of these ways of working on public, worldwide visible code and other IP. It is common that one of licenses approved by the OSI or the Creative Commons is applied to such material to set clear expectations with regards to allowed and expected use of the public. See the [FOSS Terms guide]() for this.
+- *Open Source* refers to the use of these ways of working on public, worldwide visible code and other IP. It is common that one of the licenses approved by the OSI or the Creative Commons is applied to such material to set clear expectations with regards to allowed and expected use of the public. See the [FOSS Terms guide](https://github.com/project-origin/origin-collaboration/blob/main/guides/FOSS-terms-guide/01-FOSS-Terms-Intro-TOC.md) for this.
 
 ## Why do we need defined roles in an open collaboration?
 


### PR DESCRIPTION
This is the last part of the pre-read contents, the abbreviated descriptions of the 3 roles in InnerSource and why they exist.

I've added some more specific links to the InnerSource Commons learning path and bolded a few points that are important in my view.

We could use this to link from the FOSS Terms Guide InnerSource section once this is merged. Or move it elsewhere.

With this, the pre-read material has been fulled separated into guides so we can check off #103 as more than done. 

@lauranolling maybe take a look - I think you wrote a good part of this for the pre-read. 