### PR TITLE
Fix broken relative links in work session template

### DIFF
--- a/meeting-docs/workingroup-minutes-template.md
+++ b/meeting-docs/workingroup-minutes-template.md
@@ -62,6 +62,6 @@ Put assignments here in the following format:
 [project board collaboration platform]: https://github.com/orgs/project-origin/projects/2/views/1
 [project board Energinet Open Incubator](https://github.com/orgs/project-origin/projects/11)
 
-[Scheduler]:meeting-docs/roles.md#scheduler
-[Facilitator]:meeting-docs/roles.md#facilitator
-[Scribe]:meeting-docs/roles.md#scribe
+[Scheduler]:https://github.com/project-origin/origin-collaboration/blob/main/meeting-docs/roles.md#scheduler
+[Facilitator]:https://github.com/project-origin/origin-collaboration/blob/main/meeting-docs/roles.md#facilitator
+[Scribe]:https://github.com/project-origin/origin-collaboration/blob/main/meeting-docs/roles.md#scribe


### PR DESCRIPTION
Unfortunately relative links don't work as expected, thus replace them by absolute links.

Should probably be good to go, but take a second look @lauranolling. If good to go, just merge.