### PR TITLE
Create project-origin-working-session-23-02-2023.md

### DIFF
--- a/meeting-minutes/project-origin-working-session-23-02-2023.md
+++ b/meeting-minutes/project-origin-working-session-23-02-2023.md
@@ -2,7 +2,7 @@
 
 ## Roles
 - [Scheduler]: Laura / @lauranolling 
-- [Facilitator]: Johannes / @lenucksi 
+- [Facilitator]: ?
 - [Scribe]: Thomas / @wisbech 
 
 ## Agenda


### PR DESCRIPTION
This adds the notes template with new agenda, carry-over etc. for the February 23rd, 2023 weekly sync session.

Please review, add your material, your comments on your assignments etc. before the meeting.

Updated status overview of boards
Added assignments from last weeks session
Made document ready for scribe notes