### PR TITLE
Create project-origin-working-session-16-03-2023.md

### DIFF
--- a/meeting_minutes/project-origin-working-session-16-03-2023.md
+++ b/meeting_minutes/project-origin-working-session-16-03-2023.md
@@ -1,12 +1,5 @@
 # Project Origin Working Group Meeting 16, 03, 2023
 
-Are you participating in the upcoming meeting? Then **Please check out the agenda item "_Review status of assignments from last meeting_"**:
-- See if there are any assignments for you.
-- Have you already completed the task?
-  - To keep track of what has been done, do like this: ~to strike out the assignment~.
-- Do you have any important information for everyone? 
-  - Then feel free to add a comment to the pull request.   
-
 ## Roles
 - [Scheduler]: Laura / @lauranolling 
 - [Facilitator]: Thomas / @wisbech


### PR DESCRIPTION
This adds the notes template with new agenda, carry-over etc. for the 16-03-2023 weekly sync session. Please review, add your material, your comments on your assignments etc. before the meeting @wisbech, @andersfausboll and @lenucksi. 

* Added a bit of guidance for participants going through assignments 
* Added names agreed for each of the three roles
* Added board statuses
* Added assignments from last weeks session
* Made document ready for scribe notes